### PR TITLE
Updates for Dragen v4.2.7

### DIFF
--- a/config/FastWGS/FastWGS.variables
+++ b/config/FastWGS/FastWGS.variables
@@ -3,6 +3,6 @@ callSV=true
 callRepeats=true
 post_processing_pipeline=dragenwgs_post_processing
 post_processing_pipeline_version=master
-dragen_ref="/staging/resources/human/reference/GRCh38_masked/"
+dragen_ref="/staging/resources/human/reference/GRCh38_masked_v9/"
 assembly="hg38"
 fasta="GRCh38_full_analysis_set_plus_decoy_hla_masked.fa"

--- a/config/WGS/WGS.variables
+++ b/config/WGS/WGS.variables
@@ -3,6 +3,6 @@ callSV=true
 callRepeats=true
 post_processing_pipeline=dragenwgs_post_processing
 post_processing_pipeline_version=master
-dragen_ref="/staging/resources/human/reference/GRCh38_masked/"
+dragen_ref="/staging/resources/human/reference/GRCh38_masked_v9/"
 assembly="hg38"
 fasta="GRCh38_full_analysis_set_plus_decoy_hla_masked.fa"


### PR DESCRIPTION
Closes #26 

Updates needed for Dragen v4.2.7. 
DO NOT GO LIVE UNTIL DRAGEN VERSION SWITCHED - needs to be coordinated with changes to AutoQC. 

Doneness:
- [x] Has the pipeline been run end to end by the tester?
Yes runs 220325_A01771_0007_AH2JCMDRX2, 211028_A00748_0168_AHFYNFDS and 
220506_A01771_0022_BHLV57DSX2 have been tested. 

- [x] Has the pipeline version number been incremented?
N/A as actual pipeline not changed, just the reference genome index version. 

- [x] Has the pipeline version in the variables file been updated e.g. development > master. CHECK THIS OR YOU WILL RUN DEVELOPMENT POST PROCESSING!
Not changed