### PR TITLE
update fam max

### DIFF
--- a/commands/by_family.py
+++ b/commands/by_family.py
@@ -35,7 +35,7 @@ import knapsack
 
 # set some params
 min_depth = 5 # samples below this min depth - exclude SV calling
-capacity = 5 # max number of samples to SV call at a time
+capacity = 4 # max number of samples to SV call at a time
 
 
 # ped file


### PR DESCRIPTION
Update the maximum number of SV samples to process at once.

If this doesn't work try the --bin_memory option to reduce amount of reads loaded at once.


